### PR TITLE
fixed compile on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/harfbuzz-icu-freetype)
 
 file(GLOB SOURCES src/*.cpp)
 add_executable(${EXECUTABLE_NAME} ${SOURCES})
-target_link_libraries(${EXECUTABLE_NAME} freetype harfbuzz icucommon glfw libglew_static)
+target_link_libraries(${EXECUTABLE_NAME} harfbuzz icucommon freetype glfw libglew_static)
 
 # Copy resources
 file(GLOB_RECURSE RESOURCES ${PROJECT_SOURCE_DIR}/fonts/*)

--- a/src/freetypelib.cpp
+++ b/src/freetypelib.cpp
@@ -11,7 +11,13 @@ FreeTypeLib::~FreeTypeLib() {
 FT_Face* FreeTypeLib::loadFace(const string& fontName, int ptSize, int deviceHDPI, int deviceVDPI) {
     FT_Face* face = new FT_Face;
 
-    FT_New_Face(lib, fontName.c_str(), 0, face);
+    auto error = FT_New_Face(lib, fontName.c_str(), 0, face);
+    if (FT_Err_Unknown_File_Format == error) {
+      std::cerr << "cannot open font file\n";
+    } else if (error) {
+
+      std::cerr << "unknown error loading file " <<  fontName << "\n";
+    }
     force_ucs2_charmap(*face);
     FT_Set_Char_Size(*face, 0, ptSize, deviceHDPI, deviceVDPI);
 


### PR DESCRIPTION
On Linux (Ubunt 18.04) compile fails with the following error:

```
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
make -f harfbuzz-icu-freetype/CMakeFiles/harfbuzz.dir/build.make harfbuzz-icu-freetype/CMakeFiles/harfbuzz.dir/build
make[2]: Entering directory '/home/nan/p/harfbuzz-example/build'
make[2]: Nothing to be done for 'harfbuzz-icu-freetype/CMakeFiles/harfbuzz.dir/build'.
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
[ 34%] Built target harfbuzz
make -f harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/build.make harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/depend
make[2]: Entering directory '/home/nan/p/harfbuzz-example/build'
cd /home/nan/p/harfbuzz-example/build && /usr/local/lib/python3.6/dist-packages/cmake/data/bin/cmake -E cmake_depends "Unix Makefiles" /home/nan/p/harfbuzz-example /home/nan/p/harfbuzz-example/harfbuzz-icu-freetype /home/nan/p/harfbuzz-example/build /home/nan/p/harfbuzz-example/build/harfbuzz-icu-freetype /home/nan/p/harfbuzz-example/build/harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
make -f harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/build.make harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/build
make[2]: Entering directory '/home/nan/p/harfbuzz-example/build'
make[2]: Nothing to be done for 'harfbuzz-icu-freetype/CMakeFiles/icucommon.dir/build'.
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
[ 99%] Built target icucommon
make -f CMakeFiles/harfbuzz-example.out.dir/build.make CMakeFiles/harfbuzz-example.out.dir/depend
make[2]: Entering directory '/home/nan/p/harfbuzz-example/build'
cd /home/nan/p/harfbuzz-example/build && /usr/local/lib/python3.6/dist-packages/cmake/data/bin/cmake -E cmake_depends "Unix Makefiles" /home/nan/p/harfbuzz-example /home/nan/p/harfbuzz-example /home/nan/p/harfbuzz-example/build /home/nan/p/harfbuzz-example/build /home/nan/p/harfbuzz-example/build/CMakeFiles/harfbuzz-example.out.dir/DependInfo.cmake --color=
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
make -f CMakeFiles/harfbuzz-example.out.dir/build.make CMakeFiles/harfbuzz-example.out.dir/build
make[2]: Entering directory '/home/nan/p/harfbuzz-example/build'
[ 99%] Linking CXX executable bin/harfbuzz-example.out
/usr/local/lib/python3.6/dist-packages/cmake/data/bin/cmake -E cmake_link_script CMakeFiles/harfbuzz-example.out.dir/link.txt --verbose=1
/usr/bin/c++   -Wall -std=c++11  -rdynamic CMakeFiles/harfbuzz-example.out.dir/src/freetypelib.cpp.o CMakeFiles/harfbuzz-example.out.dir/src/main.cpp.o  -o bin/harfbuzz-example.out harfbuzz-icu-freetype/freetype/libfreetype.a harfbuzz-icu-freetype/libharfbuzz.a harfbuzz-icu-freetype/libicucommon.a glfw/src/libglfw3.a lib/libglew.a -lrt -lm -lX11 -lpthread -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor -lGL -lX11 -ldl -lXext 
harfbuzz-icu-freetype/libharfbuzz.a(hb-ft.cc.o): In function `hb_ft_font_set_funcs':
hb-ft.cc:(.text+0x1452): undefined reference to `FT_Set_Var_Blend_Coordinates'
collect2: error: ld returned 1 exit status
CMakeFiles/harfbuzz-example.out.dir/build.make:111: recipe for target 'bin/harfbuzz-example.out' failed
make[2]: *** [bin/harfbuzz-example.out] Error 1
make[2]: Leaving directory '/home/nan/p/harfbuzz-example/build'
CMakeFiles/Makefile2:76: recipe for target 'CMakeFiles/harfbuzz-example.out.dir/all' failed
make[1]: *** [CMakeFiles/harfbuzz-example.out.dir/all] Error 2
make[1]: Leaving directory '/home/nan/p/harfbuzz-example/build'
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
make: Leaving directory '/home/nan/p/harfbuzz-example/build'
```

It's a simple fix of reordering the library in proper order.